### PR TITLE
Add frontend integration guide for HTTP API

### DIFF
--- a/docs/chess-frontend-integration.md
+++ b/docs/chess-frontend-integration.md
@@ -1,0 +1,100 @@
+# Chess Engine HTTP API Frontend Guide
+
+## Purpose & Audience
+- Summarize the HTTP contracts this engine exposes for a future web GUI.
+- Highlight session lifecycle, payloads, and telemetry that the UI should surface.
+- Capture engine strengths and current risks that influence UX decisions.
+
+## Service Overview
+- Base URL (local dev): `http://localhost:8000`.【F:docs/openapi.yaml†L5-L7】
+- Health probe: `GET /healthz` → `{ "status": "ok" }` for readiness checks.
+  【F:docs/openapi.yaml†L8-L21】【F:src/protocol/http/app.py†L73-L76】
+- All endpoints speak JSON over HTTP; 4xx errors return FastAPI validation details or
+  structured error envelopes with `error.code`, `error.message`, and `request_id` for
+  correlation.【F:docs/openapi.yaml†L332-L363】【F:src/protocol/http/app.py†L63-L68】
+
+## Session Model
+- Games live in an in-memory, thread-safe store keyed by `game_id`; sessions
+  persist until the service restarts or an explicit delete is added later.
+  【F:src/protocol/http/session.py†L10-L50】
+- Creating a game (`POST /api/games`) returns `{game_id, fen}` seeded with the standard
+  start position.【F:docs/openapi.yaml†L22-L31】【F:src/protocol/http/app.py†L77-L82】
+- _Important_: No TTL or eviction yet; multi-user deployments should plan
+  external state or explicit cleanup once concurrency requirements are known
+  (see Plan 5 backlog).【F:docs/plans/plan-05-http-api-and-sessions.md†L24-L47】
+
+## Core Game Endpoints
+- Fetch state: `GET /api/games/{game_id}/state`.
+  - Returns FEN, legal UCI moves, checkmate/stalemate/draw flags, last move,
+    and full move history for the UI to render clocks, move list, and
+    highlights.【F:docs/openapi.yaml†L32-L49】【F:src/protocol/http/app.py†L83-L96】
+- Set position: `POST /api/games/{game_id}/position` with `{ "fen": str }`.
+  - Validates FEN; invalid strings emit `400 invalid FEN`. Use to resume saved games or
+    load puzzles.【F:docs/openapi.yaml†L50-L79】【F:src/protocol/http/app.py†L98-L116】
+- Make move: `POST /api/games/{game_id}/move` with `{ "move": "e2e4" }` in UCI
+  format.
+  - Illegal or malformed moves return `400` with either parser text or
+    `illegal move`. UI should surface these messages to help users debug
+    input.【F:docs/openapi.yaml†L80-L110】【F:src/protocol/http/app.py†L118-L141】
+- Undo: `POST /api/games/{game_id}/undo` reverts a ply; returns the refreshed
+  state.
+  - Errors (e.g., empty history) surface as 400 with a descriptive `detail`
+    string. Disable the control when `move_history` is empty.
+    【F:docs/openapi.yaml†L146-L165】【F:src/protocol/http/app.py†L199-L216】
+
+## Search Endpoint & Telemetry
+- `POST /api/games/{game_id}/search` accepts optional `depth`, `movetime_ms`,
+  and `tt_max_entries` to tune search effort.
+  【F:docs/openapi.yaml†L111-L145】【F:src/protocol/http/app.py†L143-L182】
+- Response fields to visualize:
+  - `best_move`: next engine move (nullable when search aborts early).
+  - `score`: either `{ "cp": centipawns }` or `{ "mate": plies }`; display both formats.
+  - `pv`: principal variation list for move arrows/annotations.
+  - `nodes`, `qnodes`, `seldepth`, `time_ms`: power any depth/time HUD.
+  - TT telemetry (`tt_hits`, `tt_exact_hits`, `tt_lower_hits`, `tt_upper_hits`,
+    `tt_probes`, `tt_stores`, `tt_replacements`, `tt_size`, `hashfull`) enables advanced
+    inspector panels for engine enthusiasts.
+  - `iters`: per-depth timing/node stats for iterative deepening progress
+    bars.【F:docs/openapi.yaml†L234-L331】
+- Frontend should offer presets (e.g., depth vs. movetime) and reflect
+  outstanding performance work noted in the engine status report (profiling,
+  telemetry). Highlight that scores may fluctuate due to known search cost
+  issues.【F:docs/engine-status-report.md†L3-L64】
+
+## Auxiliary Endpoint: Perft
+- `POST /api/perft` with `{ "fen": str, "depth"?: int }` returns `{ "nodes": int }` for
+  debugging move generation. Display as developer tooling or omit from
+  user-facing UI.【F:docs/openapi.yaml†L166-L194】【F:src/protocol/http/app.py†L184-L197】
+
+## Data Model Reference
+- `GameState` schema is stable and mirrored in Pydantic models; rely on these
+  fields for board rendering and status badges.
+  【F:docs/openapi.yaml†L206-L233】【F:src/protocol/http/app.py†L83-L141】
+- `SearchResult` schema includes nullable score semantics; handle `null`
+  scores when the engine fails to produce an evaluation (rare but possible
+  during aborts).【F:docs/openapi.yaml†L234-L331】
+- README lists friendly summaries suitable for onboarding documentation in the frontend
+  repo; reuse wording for quickstart sections.【F:README.md†L61-L79】
+
+## Error Handling & Observability
+- Expect 404 `game not found` when reusing stale IDs; redirect users to create a fresh
+  session in that case.【F:src/protocol/http/app.py†L221-L225】
+- Validation errors (missing body fields, out-of-range depth) automatically
+  generate FastAPI 422 responses; show field-level hints if building
+  forms.【F:docs/openapi.yaml†L111-L136】【F:src/protocol/http/app.py†L63-L151】
+- Each request receives a `request_id` via middleware—log it in the UI console to help
+  trace reports.【F:docs/openapi.yaml†L332-L363】【F:src/protocol/http/app.py†L63-L68】
+
+## UX Recommendations
+- Provide clear affordances for FEN import/export since FEN drives both
+  set-position and perft operations.【F:docs/openapi.yaml†L50-L194】
+- Surface move history with ability to step backward using the undo endpoint;
+  disable undo when history is empty to avoid needless
+  requests.【F:docs/openapi.yaml†L146-L165】【F:src/protocol/http/app.py†L199-L216】
+- Consider exposing engine capabilities (quiescence, TT stats, evaluation
+  heuristics) in an "Engine Insights" panel to communicate strengths and
+  current focus areas.【F:docs/engine-status-report.md†L3-L64】
+- Call out known performance and concurrency gaps from Plan 5 when planning
+  hosted deployments; avoid assuming multi-user persistence without extra
+  infrastructure.【F:docs/plans/plan-05-http-api-and-sessions.md†L24-L47】
+

--- a/docs/frontend_vision.md
+++ b/docs/frontend_vision.md
@@ -1,0 +1,159 @@
+# Chess Web GUI Vision
+
+## Purpose
+- Provide a north star for the standalone `chess_web_gui` repository that will
+  consume this engine's HTTP API.
+- Align product, design, and engineering teams on user goals, experience
+  pillars, and technical integration constraints.
+- Document assumptions about future enhancements so the frontend can evolve in
+  lockstep with the engine roadmap.
+
+## Audience
+- Product managers defining the scope of the first public release.
+- UX and visual designers shaping information hierarchy and interaction
+  patterns.
+- Frontend engineers implementing the SPA and integration tests.
+- Developer advocates maintaining documentation and onboarding flows for
+  contributors.
+
+## Vision Statement
+Deliver a fast, insightful, and trustable chess experience that showcases the
+engine's analytical strengths while remaining approachable to casual players.
+The application should feel responsive on consumer hardware, embrace modern web
+accessibility standards, and provide progressive disclosure of advanced engine
+telemetry.
+
+## Target Personas
+1. **Learner** – casual player exploring openings and tactics, values clarity,
+   explanations, and guardrails against mistakes.
+2. **Competitor** – club-level player preparing for matches, cares about
+   accuracy, move quality, and deep analysis controls.
+3. **Enthusiast** – engine aficionado interested in raw telemetry, configurable
+   search parameters, and experimentation with different positions.
+
+## Experience Pillars
+- **Clarity** – prioritize readable board states, move histories, and
+  annotations. Surface engine opinions with context (centipawns, mate
+  distances, principal variation) and explain discrepancies across iterations.
+- **Responsiveness** – minimize perceived latency by optimistic UI updates,
+  streaming analysis updates, and caching recent sessions. All critical flows
+  should remain usable on mid-range laptops and tablets.
+- **Trustworthiness** – mirror the engine's structured errors, request IDs, and
+  version metadata so users can trace unexpected behavior and share actionable
+  bug reports.
+- **Extensibility** – keep architecture modular (board, controls, insights) to
+  accommodate future features such as puzzles, coach mode, or cloud save.
+
+## Feature Roadmap (Initial Release)
+1. **Session Management**
+   - Create, resume, and destroy sessions via `POST /api/games` and subsequent
+     calls.
+   - Persist the current `game_id` locally (e.g., IndexedDB) so refreshes retain
+     context until the backend resets.
+2. **Interactive Board**
+   - Drag-and-drop and tap-to-move interactions with move validation backed by
+     `GET /api/games/{game_id}/state` and `POST /api/games/{game_id}/move`.
+   - Highlight legal moves, last move, checks, and checkmates using state
+     payload fields.
+3. **Analysis Controls**
+   - Quick actions for depth-limited and time-limited searches calling
+     `POST /api/games/{game_id}/search` with presets (blitz/classical/custom).
+   - Display engine score, mate distance, principal variation, nodes, and
+     selective depth as the search progresses.
+4. **History & Undo**
+   - Scrollable move list with SAN/lan toggles and ability to step back using
+     `POST /api/games/{game_id}/undo` and corresponding state refreshes.
+5. **Position Tools**
+   - FEN import/export dialog, board reset, and quick-start templates. Validate
+     FEN strings client-side before calling `POST /api/games/{game_id}/position`.
+6. **Insights Panel**
+   - Collapsible telemetry section exposing TT stats, iterative deepening
+     breakdown (`iters`), and hash usage (`hashfull`) for advanced users.
+7. **Perft Playground (Developer Mode)**
+   - Hidden or authenticated screen invoking `POST /api/perft` for debugging
+     move generation discrepancies.
+
+## Future Enhancements (Post-MVP)
+- Cloud-backed session persistence keyed by user identity to survive backend
+  restarts.
+- Collaborative analysis mode with shared cursors and commentary.
+- Opening explorer and endgame tablebase integrations.
+- Mobile-first layout optimizations and offline-first caching strategies.
+- Accessibility improvements such as screen-reader move announcements and
+  high-contrast themes.
+
+## Architectural Principles
+- **Single Page Application** built with a modern framework (React, Svelte, or
+  Vue) using TypeScript for type safety against the OpenAPI schema.
+- **State Management** via a predictable store (Redux Toolkit, Zustand, Pinia)
+  with normalized entities for games, analysis runs, and UI panels.
+- **API Layer** generated from `docs/openapi.yaml` to ensure parity with the
+  backend; include clients for games, search, and perft namespaces.
+- **Real-Time Feedback** using Server-Sent Events or WebSockets once the engine
+  exposes streaming updates (Plan 5 backlog). For now, poll search endpoints at
+  a cadence aligned with `movetime_ms` or depth iterations.
+- **Testing Strategy** combining unit tests (component and store), contract
+  tests against a mocked API server, and end-to-end scenarios using Playwright
+  or Cypress.
+
+## Error Handling & Observability
+- Surface backend-provided `error.code`, `error.message`, and `request_id` in
+  toast notifications and developer consoles to aid debugging.
+- Gracefully handle `404 game not found` by prompting users to start a new
+  session; offer retries for transient network failures.
+- Instrument telemetry (e.g., OpenTelemetry or custom hooks) to measure request
+  latency, move submission success rates, and search completion rates.
+- Log engine version and build metadata in a diagnostics view to aid support.
+
+## UX Guidelines
+- Keep board rendering at 60 FPS using requestAnimationFrame and memoized
+  components; fallback to CSS transitions on low-end devices.
+- Provide visual feedback during long searches (spinners, depth progress bars,
+  estimated remaining time based on `iters`).
+- Offer keyboard shortcuts for navigation (undo, redo, flip board) and ensure
+  all controls have accessible names.
+- Internationalize copy via a translation framework from day one to support
+  multi-lingual deployments.
+
+## Collaboration Expectations
+- Maintain shared design tokens (colors, spacing, typography) across web and
+  marketing surfaces to preserve brand alignment.
+- Store reusable assets (SVG pieces, icons) under `packages/ui` or equivalent
+  library to unblock future native clients.
+- Establish CI pipelines enforcing linting, formatting, type checks, and
+  integration tests before deployment.
+
+## Deployment & Ops Considerations
+- Target static hosting (Vercel, Netlify, GitHub Pages) backed by environment
+  variables pointing at the engine API base URL.
+- Support multiple environments (local, staging, production) via configuration
+  files or runtime environment injection.
+- Implement feature flags for experimental analysis options so they can ship
+  dark and be toggled remotely.
+- Document rollback and cache-busting procedures to ensure rapid recovery from
+  faulty releases.
+
+## Dependencies & Integration Contracts
+- Align release cadence with the engine roadmap; monitor changes to
+  `docs/chess-frontend-integration.md` and `docs/openapi.yaml` for contract
+  updates.
+- Coordinate with backend maintainers when introducing long-running requests or
+  higher concurrency loads.
+- Version the generated API client alongside the backend commit hash to trace
+  compatibility.
+
+## Success Metrics
+- Time-to-first-move under 5 seconds for new visitors on broadband.
+- Search result latency within ±10% of requested `movetime_ms` presets.
+- ≥90% of error dialogs include actionable guidance sourced from backend
+  messages.
+- User satisfaction (post-session survey) averages ≥4/5 on clarity and
+  responsiveness.
+
+## Open Questions
+- Should streaming analysis be prioritized over deeper synchronous searches in
+  MVP?
+- What authentication model (if any) is required for hosted deployments?
+- How should puzzles and coaching content integrate with engine analysis flows?
+- Do we need offline support beyond graceful network failure handling?
+


### PR DESCRIPTION
## Summary
- add a documentation guide to help a future chess API frontend integrate with the HTTP service
- capture endpoint contracts, session lifecycle, telemetry, and UX considerations pulled from the existing API and plans

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68d7eea031cc832d91a5b5815903b8f9